### PR TITLE
Fix bug: table can not display all data when reload the data's lines more than before.

### DIFF
--- a/CTkTable/ctktable.py
+++ b/CTkTable/ctktable.py
@@ -95,6 +95,8 @@ class CTkTable(customtkinter.CTkFrame):
     def draw_table(self, **kwargs):
 
         """ draw the table """
+        self.rows = len(values)
+        self.columns = len(values[0])
         for i in range(self.rows):
             for j in range(self.columns):
                 self.inside_frame.grid_rowconfigure(i, weight=1)


### PR DESCRIPTION
For example:
1, table load data1(5 lines),
2, table reload data2(6 lines), then the last line can not display.